### PR TITLE
Circle build fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           name: Docker Push
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              docker login -u $REGISTRY_USER -p $REGISTRY_PASSWD registry.outreach.cloud
+              echo -n "$REGISTRY_PASSWD" | docker login -u $REGISTRY_USER --passwd-stdin registry.outreach.cloud
 
               repo='registry.outreach.cloud/oauth2_proxy'
               tag=$(awk -F'"' '/^const VERSION/ {printf "%s", $$2}' version.go)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ jobs:
               repo='registry.outreach.cloud/oauth2_proxy'
               tag=$(awk -F'"' '/^const VERSION/ {printf "%s", $$2}' version.go)
 
-              docker tag oauth2_proxy:latest ${repo}:${tag}
-              docker push ${repo}:${tag}
-              docker tag oauth2_proxy:latest ${repo}:latest
+              docker tag oauth2_proxy:latest ${repo}:${tag} ${repo}:latest
+              docker push ${repo}:${tag} && docker push ${repo}:latest
             fi

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.2.1-alpha.outreach-1.0.4"
+const VERSION = "2.2.1-alpha.outreach-1.0.5"


### PR DESCRIPTION
Pipe the docker registry password via stdin instead of using `-p` option, and add latest tag to docker image