### PR TITLE
enable okta groups

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 	flagSet.Var(&googleGroups, "google-group", "restrict logins to members of this google group (may be given multiple times).")
 	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")
 	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")
+	flagSet.Bool("set-xauth-okta-groups", false, "set X-Auth-Request-Okta-Groups response headers (useful in Nginx auth_request mode), in a comma-separated string")
 	flagSet.String("okta-domain", "", "the full domain for which your organization's okta is configured (example.okta.com)")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
 	flagSet.String("client-secret", "", "the OAuth Client Secret")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -251,7 +251,7 @@ func (p *OAuthProxy) redeemCode(host, code string) (s *providers.SessionState, e
 	}
 
 	if v, ok := p.provider.(providers.HaveUserGruops); ok {
-		groups, err := v.GetUserGroups()
+		groups, err := v.GetUserGroups(s)
 		if err == nil {
 			s.Groups = strings.Join(groups, ",")
 		} else {
@@ -692,7 +692,7 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 			rw.Header().Set("X-Auth-Request-Email", session.Email)
 		}
 	}
-	if p.SetXAuthOktaGroups {
+	if p.SetXAuthOktaGroups && session.Groups != "" {
 		rw.Header().Set("X-Auth-Request-Okta-Groups", session.Groups)
 	}
 	if p.PassAccessToken && session.AccessToken != "" {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -66,6 +66,7 @@ type OAuthProxy struct {
 	PassUserHeaders     bool
 	BasicAuthPassword   string
 	PassAccessToken     bool
+	SetXAuthOktaGroups  bool
 	CookieCipher        *cookie.Cipher
 	skipAuthRegex       []string
 	skipAuthPreflight   bool
@@ -248,6 +249,16 @@ func (p *OAuthProxy) redeemCode(host, code string) (s *providers.SessionState, e
 	if s.Email == "" {
 		s.Email, err = p.provider.GetEmailAddress(s)
 	}
+
+	if v, ok := p.provider.(providers.HaveUserGruops); ok {
+		groups, err := v.GetUserGroups()
+		if err == nil {
+			s.Groups = strings.Join(groups, ",")
+		} else {
+			log.Printf("GetUserGroups failed %s", err.Error())
+		}
+	}
+
 	return
 }
 
@@ -680,6 +691,9 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 		if session.Email != "" {
 			rw.Header().Set("X-Auth-Request-Email", session.Email)
 		}
+	}
+	if p.SetXAuthOktaGroups {
+		rw.Header().Set("X-Auth-Request-Okta-Groups", session.Groups)
 	}
 	if p.PassAccessToken && session.AccessToken != "" {
 		req.Header["X-Forwarded-Access-Token"] = []string{session.AccessToken}

--- a/options.go
+++ b/options.go
@@ -59,6 +59,7 @@ type Options struct {
 	PassUserHeaders       bool     `flag:"pass-user-headers" cfg:"pass_user_headers"`
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
+	SetXAuthOktaGroups    bool     `flag:"set-xauth-okta-groups" cfg:"set_xauth_okta_groups"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
 
 	// These options allow for other providers besides Google, with

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -16,6 +16,13 @@ type Provider interface {
 	CookieForSession(*SessionState, *cookie.Cipher) (string, error)
 }
 
+// For provider like okta, we can not only know the user's email and name, it
+// also provides the groups information. This is useful for us to use that to
+// determine whether a privelege should be granted based on group membership.
+type HaveUserGruops interface {
+	GetUserGroups(*SessionState) ([]string, error)
+}
+
 func New(provider string, p *ProviderData) Provider {
 	switch provider {
 	case "myusa":

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -15,6 +15,7 @@ type SessionState struct {
 	RefreshToken string
 	Email        string
 	User         string
+	Groups       string
 }
 
 func (s *SessionState) IsExpired() bool {


### PR DESCRIPTION
Context for this change:

Need access control based on okta groups

i have couple pages which are kind of like dev tools, like browsing ongoing meeting, etc, these pages are under okta oauth. Recently, i added a new page which collects user’s audio data for speech recognition. I want to open up that pages to our AE, SDR, etc. but I don’t want them to be able to use other eng-only pages



Okta has the groups concept, that during GetUserInfo, we could receive json like this
```
2020/05/18 15:42:17 api.go:21: 200 GET https://outreach.okta.com/oauth2/v1/userinfo {"sub":"00umxwq1ylkmX6Y1K0x7","name":"Guowei Shieh","locale":"US","email":"guowei.shieh@outreach.io","preferred_username":"guowei.shieh@outreach.io","given_name":"Guowei","family_name":"Shieh","zoneinfo":"America/Los_Angeles","updated_at":1588364503,"email_verified":true,"groups":["Everyone","Product-Engineering-UX Org","jira-users","Azure - AKS Readers","Voice Intelligence Team","CONCUR: Engineering (w/o Prague)","Outreach Seattle","Azure - Voice Contributors","Engineering","Prodgineering","confluence-users","Kubernetes Production Admin","ir - lse broad product communication","Windows Users","Principal Engineers","outreach-team"]}

```

We could either 1) specify the `pass-access-token` but it only works with the case when the upstream server sits behind the proxy or 2) add some sort of x-auth-request header which passes the info to the nginx, that gets forwarded to the downstream server. This is the case when auth_request is used with oauth2_proxy

I chose #2 since our setup is ngnix with auth_request module, as I absolutely shouldn't pass the oauth token out of the oauth2_proxy.